### PR TITLE
chore: add override for stream-shift

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -77175,9 +77175,9 @@ function getStateLength (state) {
     // Since node 6.3.0 state.buffer is a BufferList not an array
     if (state.buffer.head) {
       return state.buffer.head.data.length
+    } else if (state.buffer.length > 0 && state.buffer[0]) {
+      return state.buffer[0].length
     }
-
-    return state.buffer[0].length
   }
 
   return state.length

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -75492,9 +75492,9 @@ function getStateLength (state) {
     // Since node 6.3.0 state.buffer is a BufferList not an array
     if (state.buffer.head) {
       return state.buffer.head.data.length
+    } else if (state.buffer.length > 0 && state.buffer[0]) {
+      return state.buffer[0].length
     }
-
-    return state.buffer[0].length
   }
 
   return state.length

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gcs-cache-action",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gcs-cache-action",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",
@@ -10013,9 +10013,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.2.tgz",
+      "integrity": "sha512-rV4Bovi9xx0BFzOb/X0B2GqoIjvqPCttZdu0Wgtx2Dxkj7ETyWl9gmqJ4EutWRLvtZWm8dxE+InQZX1IryZn/w=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -13807,7 +13807,7 @@
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
+        "stream-shift": "1.0.2"
       }
     },
     "eastasianwidth": {
@@ -18591,9 +18591,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.2.tgz",
+      "integrity": "sha512-rV4Bovi9xx0BFzOb/X0B2GqoIjvqPCttZdu0Wgtx2Dxkj7ETyWl9gmqJ4EutWRLvtZWm8dxE+InQZX1IryZn/w=="
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "overrides": {
+    "stream-shift": "1.0.2"
   }
 }


### PR DESCRIPTION
override or use specific node version: https://github.com/googleapis/nodejs-storage/issues/2368

- GitHub doesn't support specifying a minor version here: https://github.com/apolloio/gcs-cache-action/blob/1a3b59f82169bac718f799409173923f8a33d74b/action.yml#L33
- So we are forced to override stream-shift