### PR TITLE
[INFRA-1386] fail open on missing state

### DIFF
--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -14,7 +14,7 @@ export function getInputs(): Inputs {
     bucket: core.getInput('bucket', { required: true }),
     rootDir: core.getInput('root-dir', { required: false }),
     path: core.getInput('path', { required: true }),
-    skipUploadOnHit: core.getInput('skip-upload-on-hit', { required: false }),
+    skipUploadOnHit: core.getInput('skip-upload-on-hit') || 'true',
     key: core.getInput('key', { required: true }),
     restoreKeys: core
       .getInput('restore-keys')

--- a/src/post.ts
+++ b/src/post.ts
@@ -10,6 +10,14 @@ import { createTar } from './tar-utils';
 
 async function main() {
   const state = getState();
+
+  if (!state.targetFileName) {
+    core.warning(
+      '🚨 Skipping uploading cache because the target file name is missing.',
+    );
+    return;
+  }
+
   // state.cacheHitKind might be empty because of an intermittent issue where state isn't propagated
   // to post tasks, in that case we upload the new cache.
   if (state.cacheHitKind === 'exact' && state.skipUploadOnHit == 'true') {


### PR DESCRIPTION
Skip cache upload and log a warning when state is missing in post task
Set default `true` for `skip-upload-on-hit`