### PR TITLE
Post sizes of tars

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -378,6 +378,17 @@ function getTarCompressionMethod() {
         }
     });
 }
+function getSizeInBytes(path) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const stats = yield Promise.resolve().then(() => __importStar(__nccwpck_require__(3292))).then((fs) => fs.stat(path));
+        return stats.size;
+    });
+}
+function humanFileSize(size) {
+    const i = size === 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    return (size / Math.pow(1024, i)).toFixed(2) + ' ' + sizes[i];
+}
 function createTar(archivePath, paths, cwd) {
     return __awaiter(this, void 0, void 0, function* () {
         const compressionMethod = yield getTarCompressionMethod();
@@ -398,6 +409,8 @@ function createTar(archivePath, paths, cwd) {
             cwd,
             ...paths,
         ]);
+        const archiveSize = yield getSizeInBytes(archivePath);
+        console.log(`🔹 Created archive size: ${humanFileSize(archiveSize)}.`);
         return compressionMethod;
     });
 }
@@ -405,6 +418,8 @@ exports.createTar = createTar;
 function extractTar(archivePath, compressionMethod, cwd) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`🔹 Detected '${compressionMethod}' compression method from object metadata.`);
+        const archiveSize = yield getSizeInBytes(archivePath);
+        console.log(`🔹 Extracting archive size: ${humanFileSize(archiveSize)}.`);
         const compressionArgs = compressionMethod === CompressionMethod.GZIP
             ? ['-z']
             : compressionMethod === CompressionMethod.ZSTD_WITHOUT_LONG
@@ -80909,6 +80924,14 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 3292:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs/promises");
 
 /***/ }),
 

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -264,6 +264,17 @@ function getTarCompressionMethod() {
         }
     });
 }
+function getSizeInBytes(path) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const stats = yield Promise.resolve().then(() => __importStar(__nccwpck_require__(3292))).then((fs) => fs.stat(path));
+        return stats.size;
+    });
+}
+function humanFileSize(size) {
+    const i = size === 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    return (size / Math.pow(1024, i)).toFixed(2) + ' ' + sizes[i];
+}
 function createTar(archivePath, paths, cwd) {
     return __awaiter(this, void 0, void 0, function* () {
         const compressionMethod = yield getTarCompressionMethod();
@@ -284,6 +295,8 @@ function createTar(archivePath, paths, cwd) {
             cwd,
             ...paths,
         ]);
+        const archiveSize = yield getSizeInBytes(archivePath);
+        console.log(`🔹 Created archive size: ${humanFileSize(archiveSize)}.`);
         return compressionMethod;
     });
 }
@@ -291,6 +304,8 @@ exports.createTar = createTar;
 function extractTar(archivePath, compressionMethod, cwd) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`🔹 Detected '${compressionMethod}' compression method from object metadata.`);
+        const archiveSize = yield getSizeInBytes(archivePath);
+        console.log(`🔹 Extracting archive size: ${humanFileSize(archiveSize)}.`);
         const compressionArgs = compressionMethod === CompressionMethod.GZIP
             ? ['-z']
             : compressionMethod === CompressionMethod.ZSTD_WITHOUT_LONG
@@ -79206,6 +79221,14 @@ module.exports = require("events");
 
 "use strict";
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 3292:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("fs/promises");
 
 /***/ }),
 

--- a/src/tar-utils.ts
+++ b/src/tar-utils.ts
@@ -40,6 +40,17 @@ async function getTarCompressionMethod(): Promise<CompressionMethod> {
   }
 }
 
+async function getSizeInBytes(path: string): Promise<number> {
+  const stats = await import('fs/promises').then((fs) => fs.stat(path));
+  return stats.size;
+}
+
+function humanFileSize(size: number): string {
+  const i = size === 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  return (size / Math.pow(1024, i)).toFixed(2) + ' ' + sizes[i];
+}
+
 export async function createTar(
   archivePath: string,
   paths: string[],
@@ -67,6 +78,9 @@ export async function createTar(
     ...paths,
   ]);
 
+  const archiveSize = await getSizeInBytes(archivePath);
+  console.log(`🔹 Created archive size: ${humanFileSize(archiveSize)}.`);
+
   return compressionMethod;
 }
 
@@ -78,6 +92,9 @@ export async function extractTar(
   console.log(
     `🔹 Detected '${compressionMethod}' compression method from object metadata.`,
   );
+
+  const archiveSize = await getSizeInBytes(archivePath);
+  console.log(`🔹 Extracting archive size: ${humanFileSize(archiveSize)}.`);
 
   const compressionArgs =
     compressionMethod === CompressionMethod.GZIP


### PR DESCRIPTION
## What

Logs the size of tar archives during cache save and restore operations.

## Why

Makes it easier to debug cache efficiency and understand how much data is being transferred to/from GCS.

## Changes

- After creating a tar archive, logs the archive size (e.g. `🔹 Created archive size: 42.31 MB.`)
- Before extracting a tar archive, logs the archive size (e.g. `🔹 Extracting archive size: 42.31 MB.`)
- Sizes are formatted as human-readable strings (B, KB, MB, GB, TB)